### PR TITLE
feat: use shopt -s globstar to handle **

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     - run: |
         shopt -s globstar
-        tar -cvzf targets.tar.gz ${{ inputs.path }}
+        tar -cvzf artifact.tar ${{ inputs.path }}
       shell: bash
 
     - uses: actions/upload-artifact@v2

--- a/action.yml
+++ b/action.yml
@@ -30,8 +30,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - run: tar -cvf artifact.tar ${{ inputs.path }}
-      shell: 'bash'
+    - run: |
+        shopt -s globstar
+        tar -cvzf targets.tar.gz ${{ inputs.path }}
+      shell: bash
 
     - uses: actions/upload-artifact@v2
       with:

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     - run: |
         shopt -s globstar
-        tar -cvzf artifact.tar ${{ inputs.path }}
+        tar -cvf artifact.tar ${{ inputs.path }}
       shell: bash
 
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
By default the bash on linux has the globstar disabled, in this way the `**` does not match `/`. Enabling it, will match `**` to any string including `/`